### PR TITLE
Fix: Add ViewTransitions fallback to resolve Firefox visual issue (Closes #10)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,7 +15,7 @@ const { title, description } = Astro.props;
 <html lang='en'>
   <head>
     <MainHead title={title} description={description} />
-    <ViewTransitions />
+    <ViewTransitions fallback='swap' />
   </head>
   <body>
     <div class='mx-auto flex max-w-xl flex-col gap-8 px-4 py-16'>


### PR DESCRIPTION
## Summary

This pull request addresses issue #10  by adding a fallback for `ViewTransitions` to handle visual issues in Firefox.

## Changes Made

- Added  `"swap"` as the fallback strategy to `ViewTransitions`.
- Kept the `slide` animation for browsers that support it.
