### PR TITLE
feat: dynamically render nav links based on content availibility

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -1,12 +1,28 @@
 ---
 import NavLink from "./NavLink.astro";
+import { getCollection } from "astro:content";
+
+const allBlogPosts = await getCollection("blog");
+const allLearnings = await getCollection("learnings");
 ---
 
 <nav>
   <ul class='flex flex-wrap gap-3'>
     <li><NavLink url='/'>Timeline</NavLink></li>
-    <li><NavLink url='/blog'>Blog</NavLink></li>
-    <li><NavLink url='/learnings'>Learnings</NavLink></li>
+    {
+      allBlogPosts.length > 0 && (
+        <li>
+          <NavLink url='/blog'>Blog</NavLink>
+        </li>
+      )
+    }
+    {
+      allLearnings.length > 0 && (
+        <li>
+          <NavLink url='/learnings'>Learnings</NavLink>
+        </li>
+      )
+    }
     <li><NavLink url='/contact'>Contact</NavLink></li>
   </ul>
 </nav>


### PR DESCRIPTION
## Summary

This PR closes #8 by conditionally rendering the Blog and Learnings links in the navigation menu based on content availability.

## Changes Made

- Updated the navigation component to check for the length of blog posts and learnings before rendering the corresponding links.