### PR TITLE
Conditional Rendering & Documentation Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,61 @@ All commands are run from the root of the project, from a terminal:
 | `pnpm astro ...`       | Run CLI commands like `astro add`, `astro check` |
 | `pnpm astro -- --help` | Get help using the Astro CLI                     |
 
+## Guide: Removing `/blog` and `/learnings` Routes
+
+This guide will walk you through the process of completely removing the `/blog` and `/learnings` routes from your project.
+
+## 1. Remove Route Folders
+
+Given the folder structure:
+
+```
+src/
+└── pages/
+    ├── blog/
+    │   ├── index.astro
+    │   └── [slug]/
+    │       └── index.astro
+    └── learnings/
+        ├── index.astro
+        └── [slug]/
+            └── index.astro
+```
+
+Follow these steps to manually remove the blog and learnings routes:
+
+1. Open your project folder in your file explorer or IDE.
+
+2. Navigate to the `src/pages/` directory.
+
+3. Find the `blog` / `learnings` folder and delete it.
+
+Remember, removing these folders will delete all the Astro components and any other files contained within them. Make sure you've backed up any content you want to keep before proceeding with the deletion.
+
+## 2. Update Navigation
+
+1. Open the `src/components/` directory.
+2. Locate the `navigation.astro` file.
+3. Remove the `/blog` or `/learnings` nav links as needed.
+
+```astro
+---
+import NavLink from "./NavLink.astro";
+---
+
+<nav>
+  <ul class='flex flex-wrap gap-3'>
+    <li><NavLink url='/'>Timeline</NavLink></li>
+    <li><NavLink url='/contact'>Contact</NavLink></li>
+    <!-- Both blog and learnings nav links are removed here -->
+  </ul>
+</nav>
+```
+
+4. Save the file after making these changes and ensure your site is functioning correctly without these features.
+
+By following these steps, you will have successfully removed the `/blog` and `/learnings` routes from your project and updated all necessary files.
+
 ## Want to learn more?
 
 Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -16,28 +16,35 @@ const sortedPosts = allBlogPosts
 ---
 
 <BaseLayout title='Blog' description='All my blog posts over the years!'>
-  <ul class='flex flex-col gap-5'>
-    {
-      sortedPosts.map((post) => {
-        const formattedDate = new Date(
-          post.data.publishDate,
-        ).toLocaleDateString("en-us", {
-          year: "numeric",
-          month: "long",
-          day: "numeric",
-        });
+  {
+    sortedPosts.length > 0 ? (
+      <ul class='flex flex-col gap-5'>
+        {sortedPosts.map((post) => {
+          const formattedDate = new Date(
+            post.data.publishDate,
+          ).toLocaleDateString("en-us", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          });
 
-        return (
-          <li>
-            <BlogCard
-              name={post.data.title}
-              url={`/blog/${getSlug(post.data.title)}/`}
-              description={post.data.description}
-              time={formattedDate}
-            />
-          </li>
-        );
-      })
-    }
-  </ul>
+          return (
+            <li>
+              <BlogCard
+                name={post.data.title}
+                url={`/blog/${getSlug(post.data.title)}/`}
+                description={post.data.description}
+                time={formattedDate}
+              />
+            </li>
+          );
+        })}
+      </ul>
+    ) : (
+      <div>
+        <h2 class='mb-2 font-bold'>No Blog Posts Available</h2>
+        <p>Check back later for new content!</p>
+      </div>
+    )
+  }
 </BaseLayout>

--- a/src/pages/learnings/index.astro
+++ b/src/pages/learnings/index.astro
@@ -16,27 +16,34 @@ const sortedLearnings = allLearnings
 ---
 
 <BaseLayout title='Learnings' description='All my learnings over the years!'>
-  <ul class='flex flex-col gap-5'>
-    {
-      sortedLearnings.map((learning) => {
-        const formattedDate = new Date(
-          learning.data.publishDate,
-        ).toLocaleDateString("en-us", {
-          year: "numeric",
-          month: "long",
-          day: "numeric",
-        });
+  {
+    sortedLearnings.length > 0 ? (
+      <ul class='flex flex-col gap-5'>
+        {sortedLearnings.map((learning) => {
+          const formattedDate = new Date(
+            learning.data.publishDate,
+          ).toLocaleDateString("en-us", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          });
 
-        return (
-          <li>
-            <LearningsCard
-              name={learning.data.title}
-              url={`/learnings/${getSlug(learning.data.title)}/`}
-              time={formattedDate}
-            />
-          </li>
-        );
-      })
-    }
-  </ul>
+          return (
+            <li>
+              <LearningsCard
+                name={learning.data.title}
+                url={`/learnings/${getSlug(learning.data.title)}/`}
+                time={formattedDate}
+              />
+            </li>
+          );
+        })}
+      </ul>
+    ) : (
+      <div>
+        <h2 class='mb-2 font-bold'>No Learnings Available</h2>
+        <p>Check back later for new insights and learnings!</p>
+      </div>
+    )
+  }
 </BaseLayout>


### PR DESCRIPTION
### Summary

This PR fixes #8  by adding conditional rendering to the `/blog` and `/learnings` pages, displaying a placeholder message when no content exists, and updating the documentation to guide the removal of these routes.

### Changes Made

 - When no blog posts or learnings are available, a fallback message ("No Blog Posts Available" and "No Learnings Available") is displayed instead of an empty list.
  
 - Added a guide for removing the `/blog` and `/learnings` routes from the navigation if no content exists.
